### PR TITLE
fix precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.10
     hooks:
       - id: remove-tabs
@@ -21,7 +21,7 @@ repos:
           - prettier
           - eslint-plugin-react
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: trailing-whitespace


### PR DESCRIPTION
```
[INFO] Initializing environment for git://github.com/Lucas-C/pre-commit-hooks.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: remote error: 
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    
Check the log at /tmp/pre-commit.log
```