### PR TITLE
Fixing bracket for link in chaos testing doc 

### DIFF
--- a/content/posts/chaos-testing-guide/index.mdx
+++ b/content/posts/chaos-testing-guide/index.mdx
@@ -225,7 +225,7 @@ Let us take a look at few recommendations on how and where to run the chaos test
 We are always looking to enhance Krkn, krkn-hub and cerberus and welcome any and all suggestions and help. Please feel free to open issues or if you want to contribute yourself refer to these documents below:
  - [Krkn contributing guide](https://github.com/chaos-kubox/krkn/blob/master/docs/contribute.md)
  - [Krkn-hub contributing guide](https://github.com/chaos-kubox/krkn-hub/blob/main/docs/contribute.md)
- - [Cerberus contributing guide[(https://github.com/chaos-kubox/cerberus/blob/master/docs/contribute.md)
+ - [Cerberus contributing guide](https://github.com/chaos-kubox/cerberus/blob/master/docs/contribute.md)
 
 
 ### What's next?


### PR DESCRIPTION
Currently the link for cerberus isn't properly set up. Need to fix the direction of the bracket  